### PR TITLE
Clarify the ontology concept in context when using Universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ base_model = RoboflowUniverseModel(
     ontology=CaptionOntology(
         {
             "person": "person",
-            "a forklift": "forklift"
+            "forklift": "vehicle"
         }
 ),
     api_key="ROBOFLOW_API_KEY",

--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@ pip3 install autodistill-roboflow-universe
 
 ## Quickstart
 
+> [!NOTE]
+> Autodistill uses ontology to map model predictions to the expected class labels. For other Autodistill models, the term 'caption' is used when the model accepts prompting or a description for a prediction. When using Roboflow Universe as an Autodistill base model, the 'caption' will be the class name/label that the Universe model will return. 
+
 ```python
 from autodistill_roboflow_universe import RoboflowUniverseModel
 from autodistill.detection import CaptionOntology
 from autodistill.utils import plot
 import cv2
 
-# define an ontology to map class names to our Roboflow model prompt
+# define an ontology to map class names to our Roboflow model prompt:
 # the ontology dictionary has the format {caption: class}
 # where caption is the prompt sent to the base model, and class is the label that will
-# be saved for that caption in the generated annotations
-# then, load the model
+# be saved in the generated annotations
 
 model_configs = [
     ("PROJECT_ID", VERSION_NUMBER)


### PR DESCRIPTION
When using Universe as a base model, it is not clear what the term `caption` means unless the user has a clear understanding of the ontology concept in Autodistill. There should be a brief explanation grounding the user in what an ontology and caption means when using this module.